### PR TITLE
Colorizer redesign

### DIFF
--- a/Docs/API Specs/hCode Colorizer API.md
+++ b/Docs/API Specs/hCode Colorizer API.md
@@ -2,13 +2,14 @@
 
 ## Endpoints
 
-### `GET /color-scheme`
+### `GET /color-text`
 
 #### Parameters
 
 | Parameter | Required | Type                                  | default |
 | --------- | -------- | ------------------------------------- | ------- |
 | `mode`    | ✅        | string:`["dracula", "dark", "classic"]` | -       |
+| `content`    | ✅        | JSON:`[{"hCodeValue": 0,"startIndex": 0 "endIndex": , "tokenId": 42}]` | -       |
 
 #### Responses
 
@@ -20,11 +21,47 @@ Returns the colors corresponding to the hCode values.
 
 ```json
 [
-    {
-      "hcode": 0,
-      "name": "ANY",
-      "hexcode": "#00000"
-    },
+    {"hexcode": "#ffffff", "startIndex": 0, "endIndex": 1},
+    ...
+]
+```
+
+##### 400 Bad Request
+
+Requests might be missing a required parameter or is badly encoded.
+
+**Example response:**
+
+```json
+{
+  "error": {
+    "code": 400,
+    "type": "Bad Request",
+    "reasons": "The given reason that triggered the bad request."
+  }
+}
+```
+
+### `GET /color-text-html`
+
+#### Parameters
+
+| Parameter | Required | Type                                  | default |
+| --------- | -------- | ------------------------------------- | ------- |
+| `mode`    | ✅       | string:`["dracula", "dark", "classic"]` | -       |
+| `content` | ✅       | JSON:`{"hCodes":[{"hCodeValue": 0,"startIndex": 0 "endIndex": , "tokenId": 42}], "text":"This is a test"}` | -       |
+
+#### Responses
+
+##### 200 OK
+
+Returns the colors corresponding to the hCode values.
+
+**Example response:**
+
+```json
+[
+    "span style=\"color: #ffffff\">t</span>", "span style=\"color: #ffffff\">i</span>",
     ...
 ]
 ```

--- a/hCode_colorizer/app.py
+++ b/hCode_colorizer/app.py
@@ -3,78 +3,87 @@ import json
 from flask import Flask, Response, request, app
 import os, werkzeug
 
-
 def create_app():
     app = Flask(__name__)
     dark = [
-        {0: {"name": "ANY", "hexcode": "#ffffff"}},#1
-        {1: {"name": "KEYWORD", "hexcode": "#ff8800"}}, #2
-        {2: {"name": "LITERAL", "hexcode": "#add8e6"}},
-        {3: {"name": "CHAR_STRING_LITERAL",  "hexcode": "#006400"}},
-        {4: {"name": "COMMENT", "hexcode": "#A9A9A9"}},
-        {5: {"name": "CLASS_DECLARATOR", "hexcode": "#ff8800"}}, #2
-        {6: {"name": "FUNCTION_DECLARATOR", "hexcode": "#ffcd01"}},#3
-        {7: {"name": "VARIABLE_DECLARATOR", "hexcode": "#1870d5"}},
-        {8: {"name": "TYPE_IDENTIFIER", "hexcode": "#ffffff"}}, #1
-        {9: {"name": "FUNCTION_IDENTIFIER", "hexcode": "#ffcd01"}},#3
-        {10: {"name": "FIELD_IDENTIFIER", "hexcode": "#ffcd01"}},#3
-        {11: {"name": "ANNOTATION_DECLARATOR", "hexcode": "#ffff00"}}
+        {"name": "ANY", "hCodeValue": 0, "hexcode": "#ffffff"},  # 1
+        {"name": "KEYWORD", "hCodeValue": 1, "hexcode": "#ff8800"},  # 2
+        {"name": "LITERAL", "hCodeValue": 2, "hexcode": "#add8e6"},
+        {"name": "CHAR_STRING_LITERAL", "hCodeValue": 3, "hexcode": "#006400"},
+        {"name": "COMMENT", "hCodeValue": 4, "hexcode": "#A9A9A9"},
+        {"name": "CLASS_DECLARATOR", "hCodeValue": 5, "hexcode": "#ff8800"},  # 2
+        {"name": "FUNCTION_DECLARATOR", "hCodeValue": 6, "hexcode": "#ffcd01"},  # 3
+        {"name": "VARIABLE_DECLARATOR", "hCodeValue": 7, "hexcode": "#1870d5"},
+        {"name": "TYPE_IDENTIFIER", "hCodeValue": 8, "hexcode": "#ffffff"},  # 1
+        {"name": "FUNCTION_IDENTIFIER", "hCodeValue": 9, "hexcode": "#ffcd01"},  # 3
+        {"name": "FIELD_IDENTIFIER", "hCodeValue": 10, "hexcode": "#ffcd01"},  # 3
+        {"name": "ANNOTATION_DECLARATOR", "hCodeValue": 11, "hexcode": "#ffff00"}
     ]
-    dracula=[
-        {0:{"name": "ANY", "hexcode": "#ffffff"}},  # 1 yes
-        {1:{"name": "KEYWORD", "hexcode": "#8becfd"}},  # 2
-        {2:{"name": "LITERAL", "hexcode": "#f1fa8c"}},
-        {3:{"name": "CHAR_STRING_LITERAL", "hexcode": "#f1fa8c"}},
-        {4:{"name": "COMMENT", "hexcode": "#6272a4"}}, # yes
-        {5:{"name": "CLASS_DECLARATOR", "hexcode": "#8becfd"}},  # 2
-        {6:{"name": "FUNCTION_DECLARATOR","hexcode": "#8becfd"}},  # 3
-        {7:{"name": "VARIABLE_DECLARATOR",  "hexcode": "#1870d5"}},
-        {8:{"name": "TYPE_IDENTIFIER", "hexcode": "#ffffff"}},  # 1
-        {9:{"name": "FUNCTION_IDENTIFIER", "hexcode": "#8becfd"}},  # 3
-        {10:{"name": "FIELD_IDENTIFIER", "hexcode": "#8becfd"}},  # 3
-        {11:{"name": "ANNOTATION_DECLARATOR", "hexcode": "#6272a4"}}
+    dracula = [
+        {"name": "ANY", "hCodeValue": 0, "hexcode": "#ffffff"},  # 1 yes
+        {"name": "KEYWORD", "hCodeValue": 1, "hexcode": "#8becfd"},  # 2
+        {"name": "LITERAL", "hCodeValue": 2, "hexcode": "#f1fa8c"},
+        {"name": "CHAR_STRING_LITERAL", "hCodeValue": 3, "hexcode": "#f1fa8c"},
+        {"name": "COMMENT", "hCodeValue": 4, "hexcode": "#6272a4"},  # yes
+        {"name": "CLASS_DECLARATOR", "hCodeValue": 5, "hexcode": "#8becfd"},  # 2
+        {"name": "FUNCTION_DECLARATOR", "hCodeValue": 6, "hexcode": "#8becfd"},  # 3
+        {"name": "VARIABLE_DECLARATOR", "hCodeValue": 7, "hexcode": "#1870d5"},
+        {"name": "TYPE_IDENTIFIER", "hCodeValue": 8, "hexcode": "#ffffff"},  # 1
+        {"name": "FUNCTION_IDENTIFIER", "hCodeValue": 9, "hexcode": "#8becfd"},  # 3
+        {"name": "FIELD_IDENTIFIER", "hCodeValue": 10, "hexcode": "#8becfd"},  # 3
+        {"name": "ANNOTATION_DECLARATOR", "hCodeValue": 11, "hexcode": "#6272a4"}
     ]
-    classic=[
-        {0:{"name": "ANY", "hCodeValue": 0, "hexcode": "#000000"}},
-        {1:{"name": "KEYWORD", "hCodeValue": 1, "hexcode": "#7f0055"}},
-        {2:{"name": "LITERAL", "hCodeValue": 2, "hexcode": "#1f7199"}}, #ye
-        {3:{"name": "CHAR_STRING_LITERAL", "hCodeValue": 3, "hexcode": "#006400"}},
-        {4:{"name": "COMMENT", "hCodeValue": 4, "hexcode": "#888888"}},# yes
-        {5:{"name": "CLASS_DECLARATOR", "hCodeValue": 5, "hexcode": "#880000"}}, #yes
-        {6:{"name": "FUNCTION_DECLARATOR", "hCodeValue": 6, "hexcode": "#880000"}}, #yes
-        {7:{"name": "VARIABLE_DECLARATOR", "hCodeValue": 7, "hexcode": "#000000"}}, #yes
-        {8:{"name": "TYPE_IDENTIFIER", "hCodeValue": 8, "hexcode": "##1f7199"}},
-        {9:{"name": "FUNCTION_IDENTIFIER", "hCodeValue": 9, "hexcode": "#ffcd01"}},
-        {10:{"name": "FIELD_IDENTIFIER", "hCodeValue": 10, "hexcode": "#ffcd01"}},
-        {11:{"name": "ANNOTATION_DECLARATOR", "hCodeValue": 11, "hexcode": "#1f7199"} }#yes
+    classic = [
+        {"name": "ANY", "hCodeValue": 0, "hexcode": "#000000"},
+        {"name": "KEYWORD", "hCodeValue": 1, "hexcode": "#7f0055"},
+        {"name": "LITERAL", "hCodeValue": 2, "hexcode": "#1f7199"},  # ye
+        {"name": "CHAR_STRING_LITERAL", "hCodeValue": 3, "hexcode": "#006400"},
+        {"name": "COMMENT", "hCodeValue": 4, "hexcode": "#888888"},  # yes
+        {"name": "CLASS_DECLARATOR", "hCodeValue": 5, "hexcode": "#880000"},  # yes
+        {"name": "FUNCTION_DECLARATOR", "hCodeValue": 6, "hexcode": "#880000"},  # yes
+        {"name": "VARIABLE_DECLARATOR", "hCodeValue": 7, "hexcode": "#000000"},  # yes
+        {"name": "TYPE_IDENTIFIER", "hCodeValue": 8, "hexcode": "##1f7199"},
+        {"name": "FUNCTION_IDENTIFIER", "hCodeValue": 9, "hexcode": "#ffcd01"},
+        {"name": "FIELD_IDENTIFIER", "hCodeValue": 10, "hexcode": "#ffcd01"},
+        {"name": "ANNOTATION_DECLARATOR", "hCodeValue": 11, "hexcode": "#1f7199"}  # yes
     ]
-
 
     def colorizer(packet, mode):
         if mode == "classic":
-            return {"hexcode": classic[packet['hCodeValue']]['hexcode']}
+            return {"hexcode": classic[packet['hCodeValue']]['hexcode'], "startIndex": packet["startIndex"], "endIndex": packet["endIndex"]}
         if mode == "dracula":
-            pass
+            return {"hexcode": dracula[packet['hCodeValue']]['hexcode'], "startIndex": packet["startIndex"], "endIndex": packet["endIndex"]}
         if mode == "dark":
-            pass
+            return {"hexcode": dark[packet['hCodeValue']]['hexcode'], "startIndex": packet["startIndex"],
+                    "endIndex": packet["endIndex"]}
+
+    def colorizer_html(packet, mode):
+        if mode == "classic":
+            return 'span style='
+        if mode == "dracula":
+            return ''
+        if mode == "dark":
+            return ''
 
     @app.route("/color-scheme", methods=["GET"])
     @app.errorhandler(werkzeug.exceptions.BadRequest)
     def colorize():
+        # TODO: Language specific coloring, html: but here I need the text aswell
         mode = request.args.get("mode")
+        html = request.args.get("html")
         try:
             content = request.json
-            print(content)
         except werkzeug.exceptions.BadRequest:
             return 'Not correct format!', 400
         if type(content) != list:
             return 'Not list format!', 400
         if not all([isinstance(item, dict) for item in content]):
             return 'Not correct format!', 400
-        #result = map(colorizer, content, mode)
-        print(content[0])
-        return 'Not a valid mode! Try "classic", "dracula" or "dark', 406
 
+        if html:
+            return list(map(lambda p: colorizer_html(p, mode), content))
+        result = list(map(lambda p: colorizer(p, mode), content))
+        return json.dumps(result)
 
     return app
 

--- a/hCode_colorizer/app.py
+++ b/hCode_colorizer/app.py
@@ -6,57 +6,74 @@ import os, werkzeug
 
 def create_app():
     app = Flask(__name__)
+    dark = [
+        {0: {"name": "ANY", "hexcode": "#ffffff"}},#1
+        {1: {"name": "KEYWORD", "hexcode": "#ff8800"}}, #2
+        {2: {"name": "LITERAL", "hexcode": "#add8e6"}},
+        {3: {"name": "CHAR_STRING_LITERAL",  "hexcode": "#006400"}},
+        {4: {"name": "COMMENT", "hexcode": "#A9A9A9"}},
+        {5: {"name": "CLASS_DECLARATOR", "hexcode": "#ff8800"}}, #2
+        {6: {"name": "FUNCTION_DECLARATOR", "hexcode": "#ffcd01"}},#3
+        {7: {"name": "VARIABLE_DECLARATOR", "hexcode": "#1870d5"}},
+        {8: {"name": "TYPE_IDENTIFIER", "hexcode": "#ffffff"}}, #1
+        {9: {"name": "FUNCTION_IDENTIFIER", "hexcode": "#ffcd01"}},#3
+        {10: {"name": "FIELD_IDENTIFIER", "hexcode": "#ffcd01"}},#3
+        {11: {"name": "ANNOTATION_DECLARATOR", "hexcode": "#ffff00"}}
+    ]
+    dracula=[
+        {0:{"name": "ANY", "hexcode": "#ffffff"}},  # 1 yes
+        {1:{"name": "KEYWORD", "hexcode": "#8becfd"}},  # 2
+        {2:{"name": "LITERAL", "hexcode": "#f1fa8c"}},
+        {3:{"name": "CHAR_STRING_LITERAL", "hexcode": "#f1fa8c"}},
+        {4:{"name": "COMMENT", "hexcode": "#6272a4"}}, # yes
+        {5:{"name": "CLASS_DECLARATOR", "hexcode": "#8becfd"}},  # 2
+        {6:{"name": "FUNCTION_DECLARATOR","hexcode": "#8becfd"}},  # 3
+        {7:{"name": "VARIABLE_DECLARATOR",  "hexcode": "#1870d5"}},
+        {8:{"name": "TYPE_IDENTIFIER", "hexcode": "#ffffff"}},  # 1
+        {9:{"name": "FUNCTION_IDENTIFIER", "hexcode": "#8becfd"}},  # 3
+        {10:{"name": "FIELD_IDENTIFIER", "hexcode": "#8becfd"}},  # 3
+        {11:{"name": "ANNOTATION_DECLARATOR", "hexcode": "#6272a4"}}
+    ]
+    classic=[
+        {0:{"name": "ANY", "hCodeValue": 0, "hexcode": "#000000"}},
+        {1:{"name": "KEYWORD", "hCodeValue": 1, "hexcode": "#7f0055"}},
+        {2:{"name": "LITERAL", "hCodeValue": 2, "hexcode": "#1f7199"}}, #ye
+        {3:{"name": "CHAR_STRING_LITERAL", "hCodeValue": 3, "hexcode": "#006400"}},
+        {4:{"name": "COMMENT", "hCodeValue": 4, "hexcode": "#888888"}},# yes
+        {5:{"name": "CLASS_DECLARATOR", "hCodeValue": 5, "hexcode": "#880000"}}, #yes
+        {6:{"name": "FUNCTION_DECLARATOR", "hCodeValue": 6, "hexcode": "#880000"}}, #yes
+        {7:{"name": "VARIABLE_DECLARATOR", "hCodeValue": 7, "hexcode": "#000000"}}, #yes
+        {8:{"name": "TYPE_IDENTIFIER", "hCodeValue": 8, "hexcode": "##1f7199"}},
+        {9:{"name": "FUNCTION_IDENTIFIER", "hCodeValue": 9, "hexcode": "#ffcd01"}},
+        {10:{"name": "FIELD_IDENTIFIER", "hCodeValue": 10, "hexcode": "#ffcd01"}},
+        {11:{"name": "ANNOTATION_DECLARATOR", "hCodeValue": 11, "hexcode": "#1f7199"} }#yes
+    ]
+
+
+    def colorizer(packet, mode):
+        if mode == "classic":
+            return {"hexcode": classic[packet['hCodeValue']]['hexcode']}
+        if mode == "dracula":
+            pass
+        if mode == "dark":
+            pass
 
     @app.route("/color-scheme", methods=["GET"])
     @app.errorhandler(werkzeug.exceptions.BadRequest)
     def colorize():
         mode = request.args.get("mode")
-        if mode == "dark":
-            return json.dumps([
-                {"name": "ANY", "hCodeValue": 0, "hexcode": "#ffffff"},#1
-                {"name": "KEYWORD", "hCodeValue": 1, "hexcode": "#ff8800"}, #2
-                {"name": "LITERAL", "hCodeValue": 2, "hexcode": "#add8e6"},
-                {"name": "CHAR_STRING_LITERAL", "hCodeValue": 3, "hexcode": "#006400"},
-                {"name": "COMMENT", "hCodeValue": 4, "hexcode": "#A9A9A9"},
-                {"name": "CLASS_DECLARATOR", "hCodeValue": 5, "hexcode": "#ff8800"}, #2
-                {"name": "FUNCTION_DECLARATOR", "hCodeValue": 6, "hexcode": "#ffcd01"},#3
-                {"name": "VARIABLE_DECLARATOR", "hCodeValue": 7, "hexcode": "#1870d5"},
-                {"name": "TYPE_IDENTIFIER", "hCodeValue": 8, "hexcode": "#ffffff"}, #1
-                {"name": "FUNCTION_IDENTIFIER", "hCodeValue": 9, "hexcode": "#ffcd01"},#3
-                {"name": "FIELD_IDENTIFIER", "hCodeValue": 10, "hexcode": "#ffcd01"},#3
-                {"name": "ANNOTATION_DECLARATOR", "hCodeValue": 11, "hexcode": "#ffff00"}
-            ])
-        if mode == "dracula":
-            return json.dumps([
-                {"name": "ANY", "hCodeValue": 0, "hexcode": "#ffffff"},  # 1 yes
-                {"name": "KEYWORD", "hCodeValue": 1, "hexcode": "#8becfd"},  # 2
-                {"name": "LITERAL", "hCodeValue": 2, "hexcode": "#f1fa8c"},
-                {"name": "CHAR_STRING_LITERAL", "hCodeValue": 3, "hexcode": "#f1fa8c"},
-                {"name": "COMMENT", "hCodeValue": 4, "hexcode": "#6272a4"}, # yes
-                {"name": "CLASS_DECLARATOR", "hCodeValue": 5, "hexcode": "#8becfd"},  # 2
-                {"name": "FUNCTION_DECLARATOR", "hCodeValue": 6, "hexcode": "#8becfd"},  # 3
-                {"name": "VARIABLE_DECLARATOR", "hCodeValue": 7, "hexcode": "#1870d5"},
-                {"name": "TYPE_IDENTIFIER", "hCodeValue": 8, "hexcode": "#ffffff"},  # 1
-                {"name": "FUNCTION_IDENTIFIER", "hCodeValue": 9, "hexcode": "#8becfd"},  # 3
-                {"name": "FIELD_IDENTIFIER", "hCodeValue": 10, "hexcode": "#8becfd"},  # 3
-                {"name": "ANNOTATION_DECLARATOR", "hCodeValue": 11, "hexcode": "#6272a4"}
-            ])
-        if mode == "classic":
-            return json.dumps([
-                {"name": "ANY", "hCodeValue": 0, "hexcode": "#000000"},
-                {"name": "KEYWORD", "hCodeValue": 1, "hexcode": "#7f0055"},
-                {"name": "LITERAL", "hCodeValue": 2, "hexcode": "#1f7199"}, #ye
-                {"name": "CHAR_STRING_LITERAL", "hCodeValue": 3, "hexcode": "#006400"},
-                {"name": "COMMENT", "hCodeValue": 4, "hexcode": "#888888"},# yes
-                {"name": "CLASS_DECLARATOR", "hCodeValue": 5, "hexcode": "#880000"}, #yes
-                {"name": "FUNCTION_DECLARATOR", "hCodeValue": 6, "hexcode": "#880000"}, #yes
-                {"name": "VARIABLE_DECLARATOR", "hCodeValue": 7, "hexcode": "#000000"}, #yes
-                {"name": "TYPE_IDENTIFIER", "hCodeValue": 8, "hexcode": "##1f7199"},
-                {"name": "FUNCTION_IDENTIFIER", "hCodeValue": 9, "hexcode": "#ffcd01"},
-                {"name": "FIELD_IDENTIFIER", "hCodeValue": 10, "hexcode": "#ffcd01"},
-                {"name": "ANNOTATION_DECLARATOR", "hCodeValue": 11, "hexcode": "#1f7199"} #yes
-            ])
-        else: return 'Not a valid mode! Try "classic", "dracula" or "dark', 406
+        try:
+            content = request.json
+            print(content)
+        except werkzeug.exceptions.BadRequest:
+            return 'Not correct format!', 400
+        if type(content) != list:
+            return 'Not list format!', 400
+        if not all([isinstance(item, dict) for item in content]):
+            return 'Not correct format!', 400
+        #result = map(colorizer, content, mode)
+        print(content[0])
+        return 'Not a valid mode! Try "classic", "dracula" or "dark', 406
 
 
     return app


### PR DESCRIPTION
Redesign the colorizer API to not work as a color-scheme returner but as a actual text colorizer by returning json packets with hexcode and indices & implemented an additional endpoint that returns html code if text, hcodevalue & indices are given